### PR TITLE
Implement local card search for trade simulation

### DIFF
--- a/pages/local_search_cards.py
+++ b/pages/local_search_cards.py
@@ -1,0 +1,60 @@
+import customtkinter as ctk
+from typing import List
+from models.Carta import Carta
+from pages.search_cards import SearchCardsPage
+
+class LocalSearchCardsPage(ctk.CTkFrame):
+    """Exibe uma lista de cartas locais permitindo filtrar pelo nome."""
+    def __init__(self, master, cards: List[Carta], on_card_select=None):
+        super().__init__(master, corner_radius=12)
+        self.cards = cards
+        self.on_card_select = on_card_select
+        self.var_search = ctk.StringVar()
+        self._build()
+        self._render_cards(self.cards)
+
+    def _build(self):
+        ctk.CTkLabel(
+            self,
+            text="Buscar Cartas",
+            font=ctk.CTkFont(size=18, weight="bold")
+        ).grid(row=0, column=0, columnspan=2, pady=(0, 15))
+
+        ctk.CTkEntry(
+            self,
+            textvariable=self.var_search,
+            width=250
+        ).grid(row=1, column=0, pady=5, padx=10, sticky="w")
+        ctk.CTkButton(
+            self,
+            text="Buscar",
+            command=self.on_search
+        ).grid(row=1, column=1, padx=5)
+
+        self.results_frame = ctk.CTkScrollableFrame(self, corner_radius=12)
+        self.results_frame.grid(row=2, column=0, columnspan=2, sticky="nsew", pady=(10,0))
+        self.rowconfigure(2, weight=1)
+        self.columnconfigure(0, weight=1)
+
+    def on_search(self):
+        term = self.var_search.get().strip().lower()
+        if term:
+            filtered = [c for c in self.cards if term in c.nome.lower()]
+        else:
+            filtered = list(self.cards)
+        self._render_cards(filtered)
+
+    def _render_cards(self, cards: List[Carta]):
+        for w in self.results_frame.winfo_children():
+            w.destroy()
+        if not cards:
+            ctk.CTkLabel(self.results_frame, text="Nenhuma carta encontrada.").pack(pady=20)
+            return
+        grid_frame = ctk.CTkFrame(self.results_frame, fg_color="transparent")
+        grid_frame.pack(anchor="center", padx=10, pady=10)
+        columns = 4
+        for idx, card in enumerate(cards):
+            row = idx // columns
+            col = idx % columns
+            SearchCardsPage.create_card_widget(self, grid_frame, card, row, col)
+

--- a/pages/simulacao.py
+++ b/pages/simulacao.py
@@ -1,6 +1,7 @@
 import customtkinter as ctk
 from models.Simulacao import SimulacaoTroca
 from pages.search_cards import SearchCardsPage
+from pages.local_search_cards import LocalSearchCardsPage
 from models.ItemTroca import ItemTroca
 from models.Carta import Carta
 from tkinter import messagebox
@@ -18,8 +19,10 @@ class SimulacaoTrocaPage(ctk.CTkFrame):
     com painéis de cartas oferecidas e recebidas.
     """
 
-    def __init__(self, master):
+    def __init__(self, master, inventario=None, lista_desejos=None):
         super().__init__(master, corner_radius=12)
+        self.inventario = inventario or []
+        self.lista_desejos = lista_desejos or []
         self.simulacao = SimulacaoTroca(limite_percentual=10.0)
         self.ofertados_frames = []
         self.recebidos_frames = []
@@ -130,6 +133,33 @@ class SimulacaoTrocaPage(ctk.CTkFrame):
         SearchCardsPage(
             master=topo,
             on_card_select=lambda carta: self._selecionar_recebido(carta, indice, topo)
+        ).pack(fill="both", expand=True)
+
+    def _selecionar_do_inventario(self, indice):
+        """Abre busca limitada às cartas do inventário."""
+        if not self.inventario:
+            return
+        cartas = [item.get_carta() for item in self.inventario]
+        topo = ctk.CTkToplevel(self)
+        topo.title("Inventário")
+        topo.geometry("800x600")
+        LocalSearchCardsPage(
+            master=topo,
+            cards=cartas,
+            on_card_select=lambda c: self._selecionar_ofertado(c, indice, topo)
+        ).pack(fill="both", expand=True)
+
+    def _selecionar_da_lista_desejos(self, indice):
+        """Abre busca limitada às cartas da lista de desejos."""
+        if not self.lista_desejos:
+            return
+        topo = ctk.CTkToplevel(self)
+        topo.title("Lista de Desejos")
+        topo.geometry("800x600")
+        LocalSearchCardsPage(
+            master=topo,
+            cards=self.lista_desejos,
+            on_card_select=lambda c: self._selecionar_recebido(c, indice, topo)
         ).pack(fill="both", expand=True)
 
 


### PR DESCRIPTION
## Summary
- add LocalSearchCardsPage for filtering local card lists
- update SimulacaoTrocaPage to support inventory and wishlist search

## Testing
- `python -m py_compile pages/simulacao.py pages/local_search_cards.py`

------
https://chatgpt.com/codex/tasks/task_e_6854838ebe448327863e0d9e24677950